### PR TITLE
Add platform requirements to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,5 +26,8 @@
         }
     ],
     "minimum-stability": "stable",
-    "require": {}
+    "require": {
+      "ext-pcntl": "*",
+      "ext-sockets": "*"
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
     ],
     "minimum-stability": "stable",
     "require": {
+      "php": "^8.0",
       "ext-pcntl": "*",
       "ext-sockets": "*"
     }


### PR DESCRIPTION
Hi there,

since this package does not work without ext-sockets or ext-pcntl, you could add these to the require section of your composer.json to signal users already during installation, that they need to install dependencies :)
Also, you requie at least PHP 8.0, as you use the [Socket interface](https://www.php.net/manual/de/class.socket.php) which was intruduced in PHP 8.0.0